### PR TITLE
Fixup Content Tests

### DIFF
--- a/src/Webview/Content.cs
+++ b/src/Webview/Content.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Text;
 
 namespace Webview
@@ -10,7 +11,7 @@ namespace Webview
         public static IContent FromHtml(string html)
         {
             var dataUri = new StringBuilder("data:text/html,");
-            dataUri.Append(html);
+            dataUri.Append(Uri.EscapeDataString(html));
             return new Content(dataUri.ToString());
         }
 

--- a/tests/Webview.Tests/ContentTests.cs
+++ b/tests/Webview.Tests/ContentTests.cs
@@ -9,14 +9,14 @@ namespace Webview.Tests
         public void HtmlContentIsEncoded()
         {
             var content = Content.FromHtml("<p>foo");
-            Assert.Equal("data:text/html;charset=UTF-8;base64,PHA+Zm9v", content.ToUri());
+            Assert.Equal("data:text/html,%3Cp%3Efoo", content.ToUri());
         }
 
         [Fact]
         public void UrlContentUsesOriginalString()
         {
             var content = Content.FromUri(new Uri("http://example.com:8080/test"));
-            Assert.Equal("http://example.com:8080/test", contnet.ToUri());
+            Assert.Equal("http://example.com:8080/test", content.ToUri());
         }
     }
 }

--- a/tests/Webview.Tests/Webview.Tests.csproj
+++ b/tests/Webview.Tests/Webview.Tests.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Webview\Webview.csproj" />
+    <ProjectReference Include="..\..\src\Webview\Webview.Core.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Not encoding the URI data causes problems on macOS. Hopefully URL
encoding will be a good enough compromise between working on macOS and
Windows.