### PR TITLE
WIP: Add Invoke Callback Support

### DIFF
--- a/examples/Eval/Program.cs
+++ b/examples/Eval/Program.cs
@@ -13,6 +13,7 @@ namespace Eval
             var html = @"<html><body><h1>Eval</h1><div id='content'></div></body></html>";
             var webview = new WebviewBuilder("Eval", Content.FromHtml(html))
                 .WithSize(new Size(1024, 768))
+                .WithInvokeCallback((view, payload) => Console.WriteLine($"Hello {payload}"))
                 .Debug()
                 .Build();
 
@@ -26,6 +27,11 @@ namespace Eval
                 {
                     timeout = DateTime.Now + duration;
                     webview.Eval(@"document.getElementById('content').textContent = 'Time:" + DateTime.Now.ToString() + "'");
+                }
+
+                if (tick % 100 == 0)
+                {
+                    webview.Eval($@"external.invoke('world @ {tick}')");
                 }
 
                 webview.Title = $"Eval - tick:{tick++.ToString()}";

--- a/src/Webview/Ffi.cs
+++ b/src/Webview/Ffi.cs
@@ -5,7 +5,7 @@ namespace Webview
 {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate void webview_external_invoke_cb_t(
-        IntPtr webview,
+        UIntPtr webview,
         [MarshalAs(UnmanagedType.LPStr)] string arg);
 
     internal static class Ffi


### PR DESCRIPTION
This seems to work. We keep hold of the callback the user has given us
and register our own in its place. When an invoke request arrives back
validate it really is for this instance and forward the request on to
the user's action.

NOTE: This doesn't properly handle the pinning of the delegate here. Not
sure what the full solution is to that yet.

TODO:

 * [ ] What happens if the delegate instance is garbage collected?

Completes: #12 