### PR TITLE
Add WebView.Exit

### DIFF
--- a/src/Webview/Webview.cs
+++ b/src/Webview/Webview.cs
@@ -82,6 +82,14 @@ namespace Webview
         }
 
         /// <summary>
+        /// Exit the webview window.
+        /// </summary>
+        public void Exit()
+        {
+            webview_exit(_webview);
+        }
+
+        /// <summary>
         /// Run a single loop 
         /// </summary>
         /// <returns></returns>


### PR DESCRIPTION
Webview.Run would call loop and then exit once finished. It was not
possible to write your own Run function with some work happening
inbetween the loops because exit was not exposed to cleanup properly at
the end.